### PR TITLE
[owl] [bug] Fix model config embedding size

### DIFF
--- a/services/api/src/owl/configs/models.json
+++ b/services/api/src/owl/configs/models.json
@@ -48,7 +48,7 @@
       "id": "ellm/BAAI/bge-small-en-v1.5",
       "name": "ELLM BAAI BGE Small EN v1.5",
       "context_length": 512,
-      "embedding_size": 1024,
+      "embedding_size": 384,
       "languages": ["mul"],
       "capabilities": ["embed"],
       "deployments": [


### PR DESCRIPTION
Updated the embedding_size for the "ELLM BAAI BGE Small EN v1.5" model to 384 in models.json.