### PR TITLE
feat: ingest URL content into knowledge table

### DIFF
--- a/services/api/src/owl/types/__init__.py
+++ b/services/api/src/owl/types/__init__.py
@@ -929,6 +929,30 @@ class FileEmbedFormData(BaseModel):
     ] = 200
 
 
+class URLEmbedFormData(BaseModel):
+    url: Annotated[str, Field(description="The URL to extract content from.")]
+    table_id: Annotated[SanitisedNonEmptyStr, Field(description="Knowledge Table ID.")]
+    chunk_size: Annotated[
+        int, Field(gt=0, description="Maximum chunk size (number of characters). Must be > 0.")
+    ] = 2000
+    chunk_overlap: Annotated[
+        int, Field(ge=0, description="Overlap in characters between chunks. Must be >= 0.")
+    ] = 200
+
+    @field_validator("url", mode="before")
+    @classmethod
+    def validate_url_format(cls, v: str) -> str:
+        """Validate URL format: must be http or https."""
+        if not isinstance(v, str):
+            raise ValueError("URL must be a string")
+        v = v.strip()
+        if not v.startswith(("http://", "https://")):
+            raise ValueError("URL must start with http:// or https://")
+        if len(v) < 10:  # Minimum viable URL length
+            raise ValueError("URL is too short")
+        return v
+
+
 class TableDataImportFormData(BaseModel):
     file: Annotated[UploadFile, File(description="The CSV or TSV file.")]
     file_name: Annotated[str, Field(description="File name.", deprecated=True)] = ""

--- a/services/api/src/owl/url_loader.py
+++ b/services/api/src/owl/url_loader.py
@@ -1,0 +1,72 @@
+"""URL content loader for knowledge table embedding."""
+
+from typing import Tuple
+from urllib.parse import urlparse
+
+import httpx
+from bs4 import BeautifulSoup
+
+# Maximum content size: 50MB
+MAX_CONTENT_SIZE = 50 * 1024 * 1024
+
+
+async def load_url_content(url: str, timeout: int = 30) -> Tuple[str, str]:
+    """
+    Fetch and extract text content from URL.
+
+    Args:
+        url: The URL to fetch
+        timeout: Request timeout in seconds
+
+    Returns:
+        Tuple of (content_text, filename_identifier)
+
+    Raises:
+        httpx.HTTPError: If the URL cannot be fetched
+        ValueError: If URL is invalid or content exceeds size limit
+    """
+    try:
+        async with httpx.AsyncClient(limits=httpx.Limits(max_connections=1)) as client:
+            response = await client.get(
+                url,
+                timeout=timeout,
+                follow_redirects=True,
+                headers={"User-Agent": "JamAIBase/1.0"},
+            )
+            response.raise_for_status()
+
+            # Check Content-Length header before full download
+            content_length = response.headers.get("content-length")
+            if content_length:
+                try:
+                    size = int(content_length)
+                    if size > MAX_CONTENT_SIZE:
+                        raise ValueError(
+                            f"Content size ({size} bytes) exceeds maximum allowed ({MAX_CONTENT_SIZE} bytes)"
+                        )
+                except ValueError:
+                    pass  # If conversion fails, proceed with download
+
+    except httpx.InvalidURL as e:
+        raise ValueError(f"Invalid URL: {url}") from e
+    except httpx.HTTPError as e:
+        raise ValueError(f"Failed to fetch URL: {str(e)}") from e
+
+    soup = BeautifulSoup(response.content, "html.parser")
+
+    # Remove noise
+    for tag in soup(["script", "style", "meta", "link"]):
+        tag.decompose()
+
+    content = soup.get_text(separator="\n", strip=True)
+
+    # Validate extracted content is not empty
+    if not content or len(content.strip()) < 10:
+        raise ValueError("URL content is empty or too short")
+
+    # Use domain as filename-like identifier
+    parsed = urlparse(url)
+    domain = parsed.netloc.replace("www.", "")
+    filename = f"{domain}_content.txt"
+
+    return content, filename


### PR DESCRIPTION
## feat: Direct URL ingestion for Knowledge Tables

### Problem
Today users must manually scrape a URL, save the content to a file, and then upload that file into a Knowledge Table. This adds friction and slows down knowledge base construction.

### Solution
Introduce a first-class URL ingestion endpoint: `POST /v2/gen_tables/knowledge/embed_url`.  
The endpoint fetches the URL, extracts readable text, and then reuses the existing Knowledge Table embedding/ingestion pipeline so chunking, embeddings, and storage behave consistently with file-based ingestion.

---

## Changes
- **services/api/src/owl/url_loader.py** (NEW): Async URL fetch + HTML parsing + content validation (non-empty/meaningful text)
- **services/api/src/owl/types/__init__.py**: Add `URLEmbedFormData` (URL field + validation wiring)
- **services/api/src/owl/routers/gen_table.py**: Add `POST /v2/gen_tables/knowledge/embed_url` + `OPTIONS` preflight; integrates URL content into the existing ingestion flow

---

## Safety / Robustness (current behavior)
- URL format validation + fetch error handling (invalid URL / HTTP errors)
- Configurable request timeout (default: 30s)
- Best-effort size guard via `Content-Length` pre-check (50MB max; note: not a hard streaming cap)
- HTML cleanup prior to extraction (removes script/style/meta/link) and rejects empty/too-short extracted content
- Uses existing permission/quota checks from the current ingestion path

### Follow-ups (if maintainers prefer)
- Add SSRF protections (block localhost/private/link-local ranges + DNS-resolved private IPs)
- Enforce hard max-bytes limit via streaming download (independent of `Content-Length`)
- Add content-type allowlist (e.g `text/html`, `text/plain`) + redirect cap

---

## API
`POST /v2/gen_tables/knowledge/embed_url`

```json
{
  "url": "https://example.com",
  "table_id": "knowledge_table_id",
  "chunk_size": 2000,
  "chunk_overlap": 200
}
